### PR TITLE
Extend malformed URL regression tests

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -133,8 +133,14 @@ def normalize_url(raw: str, base: str) -> Optional[str]:
         return None
     if raw.startswith("//"):
         raw = "https:" + raw
-    url = urljoin(base, raw)
-    parsed = urlparse(url)
+    try:
+        url = urljoin(base, raw)
+    except ValueError:
+        return None
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
     if parsed.scheme not in {"http", "https"}:
         return None
     # remove tracking query params
@@ -147,8 +153,14 @@ def normalize_js_url(raw: str, base: str) -> Optional[str]:
     if candidate.startswith("//"):
         candidate = "https:" + candidate
     if candidate.startswith("/"):
-        candidate = urljoin(base, candidate)
-    parsed = urlparse(candidate)
+        try:
+            candidate = urljoin(base, candidate)
+        except ValueError:
+            return None
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return None
     if parsed.scheme not in {"http", "https"}:
         return None
     if COOKIE_LIKE_RE.search(candidate):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -42,6 +42,34 @@ def test_normalize_js_url_filters_cookies():
     )
 
 
+def test_normalize_url_ignores_invalid_ipv6():
+    assert (
+        normalize_url("http://[::ffff:300.1.1.1]/", "https://example.com")
+        is None
+    )
+
+
+def test_normalize_js_url_ignores_invalid_ipv6():
+    assert (
+        normalize_js_url("http://[::ffff:300.1.1.1]/", "https://example.com")
+        is None
+    )
+
+
+def test_normalize_url_handles_invalid_base_join():
+    assert (
+        normalize_url("/path", "http://[::ffff:300.1.1.1]/")
+        is None
+    )
+
+
+def test_normalize_js_url_handles_invalid_base_join():
+    assert (
+        normalize_js_url("'/api'", "http://[::ffff:300.1.1.1]/script.js")
+        is None
+    )
+
+
 class DummyClient:
     def __init__(self):
         self.payloads = []


### PR DESCRIPTION
## Summary
- add regression coverage for urljoin failures when normalizing URLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dbea8d1a088331a51bcd331059a572